### PR TITLE
Now handling file write with a defensive check

### DIFF
--- a/src/jvmMain/kotlin/com/gu/ophan/FileRecordStore.kt
+++ b/src/jvmMain/kotlin/com/gu/ophan/FileRecordStore.kt
@@ -9,7 +9,11 @@ actual class FileRecordStore actual constructor(path: String): RecordStore {
     private val directory = File(path).apply { mkdirs() }
 
     override fun putRecord(key: String, record: ByteArray) {
-        recordFile(key).writeBytes(record)
+        val file = recordFile(key)
+        // recordstore file is in cache and can be delete by OS, check if it exist
+        if(file.exists()) {
+            file.writeBytes(record)
+        }
     }
 
     override fun getRecords(): List<ByteArray> {


### PR DESCRIPTION
## What does this change?
This PR adds a defensive check before it writes to the file system. We have observed crash events in android where app crashes due to trying to write to a file that does not exist. On Android system can remove the files from the `cache` folder at any time hence this defensive check.
 
## How to test
Build and run the app with this updated version and see events are being sent successfully
 
## How can we measure success?
The app should not crash anymore
Here is the current [crash log](https://console.firebase.google.com/project/guardian-daily-edition/crashlytics/app/android:com.guardian.editions/issues/53feeef93ac4be44176936f65d9fef49?time=last-ninety-days&sessionEventKey=5F7E444E025700016C0C0EFBA7FD8289_1459655137011040673)

## Have we considered potential risks?
It is a simple change and should not have any side effect

