### PR TITLE
Handling missing cache dir

### DIFF
--- a/MultiplatformOphan.podspec
+++ b/MultiplatformOphan.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'MultiplatformOphan'
-    spec.version                  = '0.1.8'
+    spec.version                  = '0.1.9'
     spec.homepage                 = 'https://github.com/guardian/multiplatform-ophan'
     spec.source                   = { :http => "https://bintray.com/api/ui/download/guardian/kotlin/com/gu/kotlin/multiplatform-ophan-ios/#{spec.version}/multiplatform-ophan-ios-#{spec.version}.zip" }
     spec.authors                  = 'Max Spencer'

--- a/MultiplatformOphan.podspec
+++ b/MultiplatformOphan.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'MultiplatformOphan'
-    spec.version                  = '0.1.9'
+    spec.version                  = '0.1.10'
     spec.homepage                 = 'https://github.com/guardian/multiplatform-ophan'
     spec.source                   = { :http => "https://bintray.com/api/ui/download/guardian/kotlin/com/gu/kotlin/multiplatform-ophan-ios/#{spec.version}/multiplatform-ophan-ios-#{spec.version}.zip" }
     spec.authors                  = 'Max Spencer'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Kotlin Multiplatform client library for Ophan. Available for Android, iOS, and
 
 ## Adding as a dependency
 
-The most recent version is `0.1.8`
+The most recent version is `0.1.9`
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Kotlin Multiplatform client library for Ophan. Available for Android, iOS, and
 
 ## Adding as a dependency
 
-The most recent version is `0.1.9`
+The most recent version is `0.1.10`
 
 ### Android
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,5 +1,5 @@
 group = "com.gu.kotlin"
-version = "0.1.8"
+version = "0.1.9"
 
 Properties bintrayProperties = new Properties()
 try {
@@ -24,10 +24,10 @@ bintray {
         licenses = ["MIT"]
         vcsUrl = "https://github.com/guardian/multiplatform-ophan.git"
         version {
-            name = "0.1.8"
-            desc = "Multiplatform Ophan 0.1.8"
+            name = "0.1.9"
+            desc = "Multiplatform Ophan 0.1.9"
             released = new Date()
-            vcsTag = "v0.1.8"
+            vcsTag = "v0.1.9"
         }
     }
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,5 +1,5 @@
 group = "com.gu.kotlin"
-version = "0.1.9"
+version = "0.1.10"
 
 Properties bintrayProperties = new Properties()
 try {
@@ -24,10 +24,10 @@ bintray {
         licenses = ["MIT"]
         vcsUrl = "https://github.com/guardian/multiplatform-ophan.git"
         version {
-            name = "0.1.9"
-            desc = "Multiplatform Ophan 0.1.9"
+            name = "0.1.10"
+            desc = "Multiplatform Ophan 0.1.10"
             released = new Date()
-            vcsTag = "v0.1.9"
+            vcsTag = "v0.1.10"
         }
     }
 }

--- a/src/commonMain/kotlin/com/gu/ophan/OphanDispatcher.kt
+++ b/src/commonMain/kotlin/com/gu/ophan/OphanDispatcher.kt
@@ -118,7 +118,7 @@ class OphanDispatcher(
             }
         }
         logger?.debug("OphanDispatcher", response.readText())
-        logger?.debug("OphanDispatcher","It worked, the current version is 0.1.8")
+        logger?.debug("OphanDispatcher","It worked, the current version is 0.1.9")
         return response
     }
 

--- a/src/commonMain/kotlin/com/gu/ophan/OphanDispatcher.kt
+++ b/src/commonMain/kotlin/com/gu/ophan/OphanDispatcher.kt
@@ -118,7 +118,7 @@ class OphanDispatcher(
             }
         }
         logger?.debug("OphanDispatcher", response.readText())
-        logger?.debug("OphanDispatcher","It worked, the current version is 0.1.9")
+        logger?.debug("OphanDispatcher","It worked, the current version is 0.1.10")
         return response
     }
 

--- a/src/jvmMain/kotlin/com/gu/ophan/FileRecordStore.kt
+++ b/src/jvmMain/kotlin/com/gu/ophan/FileRecordStore.kt
@@ -10,10 +10,12 @@ actual class FileRecordStore actual constructor(path: String): RecordStore {
 
     override fun putRecord(key: String, record: ByteArray) {
         val file = recordFile(key)
-        // recordstore file is in cache and can be delete by OS, check if it exist
-        if(file.exists()) {
-            file.writeBytes(record)
+        // recordstore file is in cache and can be delete by OS, create it if not exists
+        if(!file.exists()) {
+            file.mkdirs()
         }
+
+        file.writeBytes(record)
     }
 
     override fun getRecords(): List<ByteArray> {

--- a/src/jvmMain/kotlin/com/gu/ophan/FileRecordStore.kt
+++ b/src/jvmMain/kotlin/com/gu/ophan/FileRecordStore.kt
@@ -10,8 +10,8 @@ actual class FileRecordStore actual constructor(path: String): RecordStore {
 
     override fun putRecord(key: String, record: ByteArray) {
         val file = recordFile(key)
-        // recordstore file is in cache and can be delete by OS, create it if not exists
-        if(!file.exists()) {
+        // recordstore file is in 'cache'git and can be delete by OS, create it if not exists
+        if(!directory.exists()) {
             file.mkdirs()
         }
 

--- a/src/jvmMain/kotlin/com/gu/ophan/FileRecordStore.kt
+++ b/src/jvmMain/kotlin/com/gu/ophan/FileRecordStore.kt
@@ -10,7 +10,7 @@ actual class FileRecordStore actual constructor(path: String): RecordStore {
 
     override fun putRecord(key: String, record: ByteArray) {
         val file = recordFile(key)
-        // recordstore file is in 'cache'git and can be delete by OS, create it if not exists
+        // record store directory is in the `cache` and can be deleted by the OS so re-create it if it does not exist.
         if(!directory.exists()) {
             file.mkdirs()
         }


### PR DESCRIPTION
## What does this change?
This PR creates the missing parent directory in 'cache' folder when it is missing.

## How to test
Publish to bintray and use it with the app and make sure network calls are being sent with correct data

Note: the previous [PR](https://github.com/guardian/multiplatform-ophan/pull/22) was missing version info change and it did not work as expected. This previous PR was aimining to fix this [issue](https://console.firebase.google.com/project/guardian-daily-edition/crashlytics/app/android:com.guardian.editions/issues/53feeef93ac4be44176936f65d9fef49?time=last-thirty-days&sessionEventKey=5F91B4E502EE00026FBCA44B0BCDD67B_1464929810597433371)

