### PR TITLE
Missing directory creation is now limited to parent folder only

### DIFF
--- a/MultiplatformOphan.podspec
+++ b/MultiplatformOphan.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'MultiplatformOphan'
-    spec.version                  = '0.1.10'
+    spec.version                  = '0.1.11'
     spec.homepage                 = 'https://github.com/guardian/multiplatform-ophan'
     spec.source                   = { :http => "https://bintray.com/api/ui/download/guardian/kotlin/com/gu/kotlin/multiplatform-ophan-ios/#{spec.version}/multiplatform-ophan-ios-#{spec.version}.zip" }
     spec.authors                  = 'Max Spencer'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A Kotlin Multiplatform client library for Ophan. Available for Android, iOS, and
 ## Adding as a dependency
 
 The most recent version is `0.1.11`
-The most recent version is `0.1.11`
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A Kotlin Multiplatform client library for Ophan. Available for Android, iOS, and
 
 ## Adding as a dependency
 
-The most recent version is `0.1.10`
+The most recent version is `0.1.11`
+The most recent version is `0.1.11`
 
 ### Android
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,5 +1,5 @@
 group = "com.gu.kotlin"
-version = "0.1.10"
+version = "0.1.11"
 
 Properties bintrayProperties = new Properties()
 try {
@@ -24,10 +24,10 @@ bintray {
         licenses = ["MIT"]
         vcsUrl = "https://github.com/guardian/multiplatform-ophan.git"
         version {
-            name = "0.1.10"
-            desc = "Multiplatform Ophan 0.1.10"
+            name = "0.1.11"
+            desc = "Multiplatform Ophan 0.1.11"
             released = new Date()
-            vcsTag = "v0.1.10"
+            vcsTag = "v0.1.11"
         }
     }
 }

--- a/src/commonMain/kotlin/com/gu/ophan/OphanDispatcher.kt
+++ b/src/commonMain/kotlin/com/gu/ophan/OphanDispatcher.kt
@@ -118,7 +118,7 @@ class OphanDispatcher(
             }
         }
         logger?.debug("OphanDispatcher", response.readText())
-        logger?.debug("OphanDispatcher","It worked, the current version is 0.1.10")
+        logger?.debug("OphanDispatcher","It worked, the current version is 0.1.11")
         return response
     }
 

--- a/src/jvmMain/kotlin/com/gu/ophan/FileRecordStore.kt
+++ b/src/jvmMain/kotlin/com/gu/ophan/FileRecordStore.kt
@@ -12,7 +12,7 @@ actual class FileRecordStore actual constructor(path: String): RecordStore {
         val file = recordFile(key)
         // record store directory is in the `cache` and can be deleted by the OS so re-create it if it does not exist.
         if(!directory.exists()) {
-            file.mkdirs()
+            directory.mkdirs()
         }
 
         file.writeBytes(record)


### PR DESCRIPTION
## What does this change?
A bug introduced recently where the missing parent directory gets created with child 'file' object instead of the parent 'dir' object (see the screenshot)

## How to test
Deploy to bintray and test in the app

## Images
<img width="816" alt="Screen Shot 2020-11-02 at 12 08 57" src="https://user-images.githubusercontent.com/6583174/97865025-d3c8de80-1d09-11eb-9796-289605795c2d.png">
An example where `file` object incorrectly created as `dir` hence fail to read it.