### PR TITLE
Update thrift definitions from android-news-app project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,20 +115,20 @@ kotlin {
 val ophanEventModelVersion = "0.0.23"
 
 tasks.register<de.undercouch.gradle.tasks.download.Download>("downloadThriftModels") {
-    src("https://repo1.maven.org/maven2/com/gu/ophan-event-model_2.12/$ophanEventModelVersion/ophan-event-model_2.12-$ophanEventModelVersion.jar")
+    src("https://repo1.maven.org/maven2/com/gu/ophan-event-model_2.13/$ophanEventModelVersion/ophan-event-model_2.13-$ophanEventModelVersion.jar")
     dest(buildDir)
 
 }
 
 tasks.register<Copy>("extractThriftModels") {
     dependsOn("downloadThriftModels")
-    from(zipTree("$buildDir/ophan-event-model_2.12-$ophanEventModelVersion.jar"))
+    from(zipTree("$buildDir/ophan-event-model_2.13-$ophanEventModelVersion.jar"))
     include("**/*.thrift")
     into("$buildDir/thrift")
 }
 
 tasks.register<Exec>("generateThriftModels") {
-    dependsOn("extractThriftModels")
+    //dependsOn("extractThriftModels")
     executable = "java"
     args(
             "-jar", "thrifty-compiler.jar",

--- a/src/commonMain/kotlin/ophan/thrift/event/ThriftTypes.kt
+++ b/src/commonMain/kotlin/ophan/thrift/event/ThriftTypes.kt
@@ -1125,6 +1125,94 @@ data class Interaction(
     }
 }
 
+data class AppReferral(@JvmField @ThriftField(fieldId = 1, isRequired = true) val raw: String, @JvmField @ThriftField(fieldId = 2, isOptional = true) val appId: String?) : Struct {
+    override fun write(protocol: Protocol) {
+        ADAPTER.write(protocol, this)
+    }
+
+    class Builder : StructBuilder<AppReferral> {
+        private var raw: String? = null
+
+        private var appId: String? = null
+
+        constructor() {
+            this.raw = null
+            this.appId = null
+        }
+
+        constructor(source: AppReferral) {
+            this.raw = source.raw
+            this.appId = source.appId
+        }
+
+        fun raw(raw: String) = apply { this.raw = raw }
+
+        fun appId(appId: String?) = apply { this.appId = appId }
+
+        override fun build(): AppReferral = AppReferral(raw = checkNotNull(raw) { "Required field 'raw' is missing" },
+                appId = this.appId)
+        override fun reset() {
+            this.raw = null
+            this.appId = null
+        }
+    }
+
+    private class AppReferralAdapter : Adapter<AppReferral, Builder> {
+        override fun read(protocol: Protocol) = read(protocol, Builder())
+
+        override fun read(protocol: Protocol, builder: Builder): AppReferral {
+            protocol.readStructBegin()
+            while (true) {
+                val fieldMeta = protocol.readFieldBegin()
+                if (fieldMeta.typeId == TType.STOP) {
+                    break
+                }
+                when (fieldMeta.fieldId.toInt()) {
+                    1 -> {
+                        if (fieldMeta.typeId == TType.STRING) {
+                            val raw = protocol.readString()
+                            builder.raw(raw)
+                        } else {
+                            ProtocolUtil.skip(protocol, fieldMeta.typeId)
+                        }
+                    }
+                    2 -> {
+                        if (fieldMeta.typeId == TType.STRING) {
+                            val appId = protocol.readString()
+                            builder.appId(appId)
+                        } else {
+                            ProtocolUtil.skip(protocol, fieldMeta.typeId)
+                        }
+                    }
+                    else -> ProtocolUtil.skip(protocol, fieldMeta.typeId)
+                }
+                protocol.readFieldEnd()
+            }
+            protocol.readStructEnd()
+            return builder.build()
+        }
+
+        override fun write(protocol: Protocol, struct: AppReferral) {
+            protocol.writeStructBegin("AppReferral")
+            protocol.writeFieldBegin("raw", 1, TType.STRING)
+            protocol.writeString(struct.raw)
+            protocol.writeFieldEnd()
+            if (struct.appId != null) {
+                protocol.writeFieldBegin("appId", 2, TType.STRING)
+                protocol.writeString(struct.appId)
+                protocol.writeFieldEnd()
+            }
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+        }
+    }
+
+    companion object {
+        @JvmField
+        val ADAPTER: Adapter<AppReferral, Builder> = AppReferralAdapter()
+    }
+}
+
 /**
  * Information about the referrer - previous page - that the reader navigated to
  * this one from.
@@ -1138,7 +1226,8 @@ data class Referrer(
     @JvmField @ThriftField(fieldId = 7, isOptional = true) val email: String?,
     @JvmField @ThriftField(fieldId = 8, isOptional = true) val nativeAppSource: Source?,
     @JvmField @ThriftField(fieldId = 9, isOptional = true) val google: GoogleReferral?,
-    @JvmField @ThriftField(fieldId = 11, isOptional = true) val tagIdFollowed: String?
+    @JvmField @ThriftField(fieldId = 11, isOptional = true) val tagIdFollowed: String?,
+    @JvmField @ThriftField(fieldId = 12, isOptional = true) val appReferral: AppReferral?
 ) : Struct {
     override fun write(protocol: Protocol) {
         ADAPTER.write(protocol, this)
@@ -1163,6 +1252,8 @@ data class Referrer(
 
         private var tagIdFollowed: String? = null
 
+        private var appReferral: AppReferral? = null
+
         constructor() {
             this.url = null
             this.component = null
@@ -1173,6 +1264,7 @@ data class Referrer(
             this.nativeAppSource = null
             this.google = null
             this.tagIdFollowed = null
+            this.appReferral = null
         }
 
         constructor(source: Referrer) {
@@ -1185,6 +1277,7 @@ data class Referrer(
             this.nativeAppSource = source.nativeAppSource
             this.google = source.google
             this.tagIdFollowed = source.tagIdFollowed
+            this.appReferral = source.appReferral
         }
 
         fun url(url: Url?) = apply { this.url = url }
@@ -1205,10 +1298,12 @@ data class Referrer(
 
         fun tagIdFollowed(tagIdFollowed: String?) = apply { this.tagIdFollowed = tagIdFollowed }
 
+        fun appReferral(appReferral: AppReferral?) = apply { this.appReferral = appReferral }
+
         override fun build(): Referrer = Referrer(url = this.url, component = this.component,
                 linkName = this.linkName, platform = this.platform, viewId = this.viewId,
                 email = this.email, nativeAppSource = this.nativeAppSource, google = this.google,
-                tagIdFollowed = this.tagIdFollowed)
+                tagIdFollowed = this.tagIdFollowed, appReferral = this.appReferral)
         override fun reset() {
             this.url = null
             this.component = null
@@ -1219,6 +1314,7 @@ data class Referrer(
             this.nativeAppSource = null
             this.google = null
             this.tagIdFollowed = null
+            this.appReferral = null
         }
     }
 
@@ -1309,6 +1405,14 @@ data class Referrer(
                             ProtocolUtil.skip(protocol, fieldMeta.typeId)
                         }
                     }
+                    12 -> {
+                        if (fieldMeta.typeId == TType.STRUCT) {
+                            val appReferral = AppReferral.ADAPTER.read(protocol)
+                            builder.appReferral(appReferral)
+                        } else {
+                            ProtocolUtil.skip(protocol, fieldMeta.typeId)
+                        }
+                    }
                     else -> ProtocolUtil.skip(protocol, fieldMeta.typeId)
                 }
                 protocol.readFieldEnd()
@@ -1362,6 +1466,11 @@ data class Referrer(
             if (struct.tagIdFollowed != null) {
                 protocol.writeFieldBegin("tagIdFollowed", 11, TType.STRING)
                 protocol.writeString(struct.tagIdFollowed)
+                protocol.writeFieldEnd()
+            }
+            if (struct.appReferral != null) {
+                protocol.writeFieldBegin("appReferral", 12, TType.STRUCT)
+                AppReferral.ADAPTER.write(protocol, struct.appReferral)
                 protocol.writeFieldEnd()
             }
             protocol.writeFieldStop()

--- a/src/commonMain/kotlin/ophan/thrift/nativeapp/ThriftTypes.kt
+++ b/src/commonMain/kotlin/ophan/thrift/nativeapp/ThriftTypes.kt
@@ -391,8 +391,8 @@ data class Event(
     @JvmField @ThriftField(fieldId = 22, isOptional = true) val ageMsLong: Long?,
     @JvmField @ThriftField(fieldId = 2, isOptional = true) val ageMs: Int? = 0,
     @JvmField @ThriftField(fieldId = 4, isOptional = true) val path: String?,
-    @JvmField @ThriftField(fieldId = 5, isOptional = true) val previousPath: String?,
-    @JvmField @ThriftField(fieldId = 6, isOptional = true) val referringSource: Source?,
+    @JvmField @ThriftField(fieldId = 5, isOptional = true) val OBSOLETE_previousPath: String?,
+    @JvmField @ThriftField(fieldId = 6, isOptional = true) val OBSOLETE_referringSource: Source?,
     @JvmField @ThriftField(fieldId = 7, isOptional = true) val pushNotificationId: String?,
     @JvmField @ThriftField(fieldId = 8, isOptional = true) val adLoad: RenderedAd?,
     @JvmField @ThriftField(fieldId = 10, isOptional = true) val benchmark: BenchmarkData?,
@@ -426,9 +426,9 @@ data class Event(
 
         private var path: String? = null
 
-        private var previousPath: String? = null
+        private var OBSOLETE_previousPath: String? = null
 
-        private var referringSource: Source? = null
+        private var OBSOLETE_referringSource: Source? = null
 
         private var pushNotificationId: String? = null
 
@@ -467,8 +467,8 @@ data class Event(
             this.ageMsLong = null
             this.ageMs = 0
             this.path = null
-            this.previousPath = null
-            this.referringSource = null
+            this.OBSOLETE_previousPath = null
+            this.OBSOLETE_referringSource = null
             this.pushNotificationId = null
             this.adLoad = null
             this.benchmark = null
@@ -493,8 +493,8 @@ data class Event(
             this.ageMsLong = source.ageMsLong
             this.ageMs = source.ageMs
             this.path = source.path
-            this.previousPath = source.previousPath
-            this.referringSource = source.referringSource
+            this.OBSOLETE_previousPath = source.OBSOLETE_previousPath
+            this.OBSOLETE_referringSource = source.OBSOLETE_referringSource
             this.pushNotificationId = source.pushNotificationId
             this.adLoad = source.adLoad
             this.benchmark = source.benchmark
@@ -524,9 +524,9 @@ data class Event(
 
         fun path(path: String?) = apply { this.path = path }
 
-        fun previousPath(previousPath: String?) = apply { this.previousPath = previousPath }
+        fun OBSOLETE_previousPath(OBSOLETE_previousPath: String?) = apply { this.OBSOLETE_previousPath = OBSOLETE_previousPath }
 
-        fun referringSource(referringSource: Source?) = apply { this.referringSource = referringSource }
+        fun OBSOLETE_referringSource(OBSOLETE_referringSource: Source?) = apply { this.OBSOLETE_referringSource = OBSOLETE_referringSource }
 
         fun pushNotificationId(pushNotificationId: String?) = apply { this.pushNotificationId = pushNotificationId }
 
@@ -561,8 +561,8 @@ data class Event(
         override fun build(): Event = Event(eventType = this.eventType,
                 eventId = checkNotNull(eventId) { "Required field 'eventId' is missing" },
                 viewId = this.viewId, ageMsLong = this.ageMsLong, ageMs = this.ageMs,
-                path = this.path, previousPath = this.previousPath,
-                referringSource = this.referringSource,
+                path = this.path, OBSOLETE_previousPath = this.OBSOLETE_previousPath,
+                OBSOLETE_referringSource = this.OBSOLETE_referringSource,
                 pushNotificationId = this.pushNotificationId, adLoad = this.adLoad,
                 benchmark = this.benchmark, networkOperation = this.networkOperation,
                 attentionMs = this.attentionMs, scrollDepth = this.scrollDepth, media = this.media,
@@ -577,8 +577,8 @@ data class Event(
             this.ageMsLong = null
             this.ageMs = 0
             this.path = null
-            this.previousPath = null
-            this.referringSource = null
+            this.OBSOLETE_previousPath = null
+            this.OBSOLETE_referringSource = null
             this.pushNotificationId = null
             this.adLoad = null
             this.benchmark = null
@@ -660,18 +660,18 @@ data class Event(
                     }
                     5 -> {
                         if (fieldMeta.typeId == TType.STRING) {
-                            val previousPath = protocol.readString()
-                            builder.previousPath(previousPath)
+                            val OBSOLETE_previousPath = protocol.readString()
+                            builder.OBSOLETE_previousPath(OBSOLETE_previousPath)
                         } else {
                             ProtocolUtil.skip(protocol, fieldMeta.typeId)
                         }
                     }
                     6 -> {
                         if (fieldMeta.typeId == TType.I32) {
-                            val referringSource = protocol.readI32().let {
+                            val OBSOLETE_referringSource = protocol.readI32().let {
                                 Source.findByValue(it) ?: throw ThriftException(ThriftException.Kind.PROTOCOL_ERROR, "Unexpected value for enum type Source: $it")
                             }
-                            builder.referringSource(referringSource)
+                            builder.OBSOLETE_referringSource(OBSOLETE_referringSource)
                         } else {
                             ProtocolUtil.skip(protocol, fieldMeta.typeId)
                         }
@@ -840,14 +840,14 @@ data class Event(
                 protocol.writeString(struct.path)
                 protocol.writeFieldEnd()
             }
-            if (struct.previousPath != null) {
-                protocol.writeFieldBegin("previousPath", 5, TType.STRING)
-                protocol.writeString(struct.previousPath)
+            if (struct.OBSOLETE_previousPath != null) {
+                protocol.writeFieldBegin("OBSOLETE_previousPath", 5, TType.STRING)
+                protocol.writeString(struct.OBSOLETE_previousPath)
                 protocol.writeFieldEnd()
             }
-            if (struct.referringSource != null) {
-                protocol.writeFieldBegin("referringSource", 6, TType.I32)
-                protocol.writeI32(struct.referringSource.value)
+            if (struct.OBSOLETE_referringSource != null) {
+                protocol.writeFieldBegin("OBSOLETE_referringSource", 6, TType.I32)
+                protocol.writeI32(struct.OBSOLETE_referringSource.value)
                 protocol.writeFieldEnd()
             }
             if (struct.pushNotificationId != null) {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

I found that the most [recent published version](https://search.maven.org/artifact/com.gu/ophan-event-model_2.13/0.0.23/jar) of the Ophan event model artifact is older than the version of the thrift definitions we use in the Android live app.

In particular, to use multiplatform-ophan in the Live app we need the recent `AppReferral` model class.

I will file an issue for that artifact being out-of-date (and see if I can fix that) separately, but for now I have manually copied across the thrift definitions we use in [android-news-app](https://github.com/guardian/android-news-app).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
